### PR TITLE
여행지 상세보기 화면구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.6.8",
         "pinia": "^2.1.7",
         "vue": "^3.4.21",
-        "vue-router": "^4.3.0"
+        "vue-router": "^4.3.0",
+        "vue3-kakao-maps": "^2.3.6"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.4",
@@ -2520,6 +2521,11 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz",
+      "integrity": "sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ=="
+    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
@@ -3798,6 +3804,14 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue3-kakao-maps": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/vue3-kakao-maps/-/vue3-kakao-maps-2.3.6.tgz",
+      "integrity": "sha512-ZwwZBG6HAA+jJap1FU76hqQ425Keje9Vm7Uk+tLZC4hdjJzgyV53F77pFV9xVczGepJJiZvE4jU0bqI6Y2u2FA==",
+      "dependencies": {
+        "kakao.maps.d.ts": "^0.1.39"
       }
     },
     "node_modules/vuetify": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "axios": "^1.6.8",
     "pinia": "^2.1.7",
     "vue": "^3.4.21",
-    "vue-router": "^4.3.0"
+    "vue-router": "^4.3.0",
+    "vue3-kakao-maps": "^2.3.6"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",

--- a/src/components/spot_detail/SpotDetail.vue
+++ b/src/components/spot_detail/SpotDetail.vue
@@ -1,0 +1,340 @@
+<template>
+    <div class="container">
+        <div class="titleType1"
+            style="height: 200px; display: flex; flex-direction: column; justify-content: center; align-items: center;">
+
+            <div style="margin-bottom: 20px;">
+                <h2 id="topTitle" style="font-size: 50px;">{{ spot.name }}</h2>
+                <div class="area_address" id="topAddr"><span>{{ spot.address }}</span></div>
+            </div>
+
+            <div style="display: flex; align-items: center; justify-content: space-between; width: 100%;">
+                <div class="left_section">
+                    <button type="button" class="btn_good" onclick="setLike();">
+                        <span class="mdi mdi-heart-outline" style="font-size: 24px;"></span>
+                        <span class="num" id="conLike">0</span>
+                    </button>
+                    <span class="num_view"><em class="tit"><span class="mdi mdi-eye-outline"
+                                style="font-size: 24px;"></span></em><span class="num" id="conRead">904</span></span>
+                </div>
+                <div class="right_section">
+                    <button type="button" class="btn_bookmark" onclick="setFavoContentDetail();">
+                        <span class="mdi mdi-bookmark-outline" style="font-size: 24px;"></span>
+                    </button>
+                    <button type="button" class="btn_print" onclick="openPrint();" title="새창 열림">
+                        <span class="mdi mdi-printer-outline" style="font-size: 24px;"></span>
+                    </button>
+                    <button type="button" class="btn_cos" onclick="myCourseCartDetail('C','12','');">
+                        <span class="mdi mdi-map" style="font-size: 24px;"></span>
+                    </button>
+                    <button type="button" class="btn_sharing" onclick="openShare();">
+                        <span class="mdi mdi-share-variant-outline" style="font-size: 24px;"></span>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="content_detail">
+            <div class="detail_tab">
+                <ul>
+                    <li class="select_tab on" id="photoTab"><a href="javascript:void(0);"
+                            @click="tabChange('galleryGo');" title="사진 보기 위치로 이동"><span>사진보기</span></a></li>
+                    <li class="select_tab" id="detailTab"><a href="javascript:void(0);" @click="tabChange('detailGo');"
+                            title="상세정보 위치로 이동"><span>상세정보</span></a></li>
+                    <li class="select_tab" id="talkTab"><a href="javascript:void(0);" @click="tabChange('replyGo');"
+                            title="여행톡 위치로 이동"><span>댓글</span></a></li>
+                    <!-- <li class="select_tab" id="recomTab"><a href="javascript:void(0);" @click="tabChange('relationGo');"
+                        title="추천여행 위치로 이동"><span>추천여행</span></a></li> -->
+                </ul>
+                <div id="galleryGo">
+                    <h3 class="blind">사진보기</h3>
+                    <div class="photo_gallery" v-if="slides.length > 0">
+                        <!-- 공사 사진 영역 -->
+                        <v-carousel height="400" width="100%" cycle hide-delimiter-background>
+                            <v-carousel-item v-for="(slide, i) in slides" :key="i">
+                                <v-sheet :color="colors[i]" height="100%">
+                                    <div class="d-flex fill-height justify-center align-center">
+                                        <div class="spotname">{{ slide }}</div>
+                                    </div>
+                                </v-sheet>
+                            </v-carousel-item>
+                        </v-carousel>
+                    </div>
+                    <div v-else>
+                        <!-- 슬라이드 로딩 중 표시할 내용 -->
+                        <p>Loading...</p>
+                    </div>
+                </div>
+
+                <div id="detailGo">
+                    <h3 class="blind">상세정보</h3>
+                    <br>
+                    <div class="description" style="text-align: left;">
+                        {{ spot.detail }}
+                    </div>
+                    <br>
+                    <KakaoMap :lat="spot.latitude" :lng="spot.hardness" :draggable="true" width="100%" height="20rem">
+                        <KakaoMapMarker :lat="spot.latitude" :lng="spot.hardness"></KakaoMapMarker>
+                    </KakaoMap>
+                    <br>
+                    <div class="moreInfo">
+                        <div class="askInfo">문의 및 안내 : {{ spot.phone }}</div>
+                        <div class="homepageInfo">홈페이지 : {{ spot.homepage }}</div>
+                        <div class="addressInfo">주소 : {{ spot.address }}</div>
+                    </div>
+
+
+                    <h3 class="blind" style="margin-top: 80px;">#tag</h3>
+                    <div class="hashtags">
+                        <v-btn v-for="(tag, index) in spot.hashtags" :key="index" @click="handleTagClick(tag)"
+                            class="tag">{{ tag }}</v-btn>
+                    </div>
+                </div>
+                <div id="replyGo">
+                    <div class="replyWrap">
+                        <!-- login 추가시 로그인 후 form -->
+                        <h3 class="tit_reply">
+                            댓글<span>2</span>
+
+                        </h3>
+                        <div class="write" id="writeReview">
+                            <div class="form">
+                                <form name="tform" id="tform">
+                                    <!-- <label class="blind" for="comment">자유롭게 댓글을 남겨주세요.</label> -->
+                                    <v-textarea class="mx-2" id="comment" label="자유롭게 댓글을 남겨주세요."
+                                        prepend-icon="mdi-comment" rows="1"></v-textarea>
+                                    <div class="fileRegbtn_wrap">
+                                        <a href="javascript:" class="btn_apply ContentComment">로그인</a>
+                                    </div>
+                                </form>
+                            </div>
+                            <div class="wrap_reply">
+                                <!-- 댓글이 있을 때 -->
+                                <div v-if="spot.comments && spot.comments.length > 0">
+                                    <!-- 댓글을 줄줄이 표시 -->
+                                    <div v-for="(comment, index) in spot.comments" :key="index" class="comment">
+                                        <div class="user_info">
+                                            <span class="mdi mdi-account-circle" style="font-size: 24px;"></span>
+                                            <span class="username">{{ comment.user }}</span> <!-- 사용자 이름 -->
+                                        </div>
+                                        <p>{{ comment.content }}</p> <!-- 댓글 내용 -->
+                                    </div>
+                                </div>
+                                <!-- 댓글이 없을 때 -->
+                                <div v-else>
+                                    <p>등록된 댓글이 없습니다.</p>
+                                </div>
+                            </div>
+
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import { KakaoMap, KakaoMapMarker } from 'vue3-kakao-maps';
+import { ref } from "vue";
+
+export default {
+    components: {
+        KakaoMap,
+        KakaoMapMarker
+    },
+    data() {
+        return {
+            spot: {},
+            colors: [],
+            slides: []
+        };
+    },
+    mounted() {
+        // 여행지 정보를 가져오는 API 호출 또는 데이터베이스 쿼리를 실행합니다.
+        // 이 예시에서는 임시로 하나의 여행지 정보를 설정합니다.
+        this.spot = {
+            id: 1,
+            name: "경복궁",
+            detail: "경복궁은 조선 시대 궁궐 중의 하나로, 한반도에 남아있는 궁중 최대의 건물군이다. 경복궁(景福宮, 영어: Gyeongbokgung Palace)은 서울특별시 종로구 사직로에 위치한 조선 왕조의 법궁(法宮, 정궁)이다. 1395년 창건되어 1592년 임진왜란으로 전소되었고, 1868년 흥선대원군의 주도로 중건되었다.",
+            latitude: 37.5796181,
+            hardness: 126.977041,
+            sido_code: 11,
+            gugun_code: 110,
+            address: "서울특별시 종로구 사직로 161",
+            homepage: "http://www.royalpalace.go.kr/",
+            phone: "02-3700-3900",
+            created_at: "2024-05-16 10:00:00",
+            updated_at: "2024-05-16 15:00:00",
+            views: 10000,
+            image: "https://cdn.visitkorea.or.kr/img/call?cmd=VIEW&amp;id=cbeefd27-1f65-4a07-8f16-6705807bae9d", // 경복궁 이미지를 가져올 링크를 여기에 넣어주세요.
+            hashtags: ["#궁궐", "#역사", "#서울"],
+            comments: [
+                {
+                    user: "사용자1",
+                    content: "이곳은 정말 아름다운 곳입니다."
+                },
+                {
+                    user: "사용자2",
+                    content: "역사를 느낄 수 있는 곳이에요."
+                }
+            ]
+        };
+        this.colors = [
+            'indigo',
+            'warning',
+            'pink darken-2',
+            'red lighten-1',
+            'deep-purple accent-4',
+        ]
+
+        this.slides = ['사진1', '사진2', '사진3', '사진4', '사진5']
+    },
+    methods: {
+        tabChange(destination) {
+            var element = document.getElementById(destination);
+            if (element) {
+                element.scrollIntoView({ behavior: "smooth" });
+            }
+        },
+        handleTagClick(tag) {
+            // 해시태그 클릭 시 수행할 동작을 정의합니다.
+            console.log("Clicked hashtag:", tag);
+            // 원하는 동작을 수행합니다.
+        }
+    }
+};
+</script>
+
+<style>
+@font-face {
+    font-family: "GongGothicMedium";
+    src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_20-10@1.0/GongGothicMedium.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+}
+
+.container {
+    width: 80%;
+    margin: 0 auto;
+    font-family: "GongGothicMedium";
+}
+
+.detail_tab ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    justify-content: space-between;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    /* padding 추가 */
+    padding: 5px;
+}
+
+.detail_tab li:not(:last-child) {
+    border-right: 1px solid #ccc;
+    padding-right: 10px;
+    /* 오른쪽 간격 조절 */
+}
+
+.detail_tab li {
+    flex: 1;
+    text-align: center;
+    text-decoration: none;
+}
+
+.detail_tab a {
+    display: inline-block;
+    padding: 10px 20px;
+    color: #777;
+}
+
+.detail_tab a:hover {
+    /* 마우스 호버시 검정색으로 변경 */
+    color: #000;
+}
+
+.hashtags {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.tag {
+    margin-right: 10px;
+    /* 원하는 간격 설정 */
+    margin-bottom: 10px;
+    /* 버튼 행 간격 설정 */
+}
+
+textarea {
+    width: 100%;
+    border: 1px solid #ccc;
+    /* 회색 테두리 */
+    padding: 8px;
+    transition: border-color 0.3s;
+    /* 테두리 색상 변화에 대한 transition 효과 */
+}
+
+textarea:focus {
+    border-color: #000;
+    /* 클릭 시 테두리 색상 변경 */
+}
+
+.comment {
+    display: flex;
+    align-items: center;
+    /* 아이콘과 텍스트를 수직 정렬 */
+    margin-bottom: 10px;
+    /* 각 댓글 사이의 간격 조절 */
+}
+
+.user_info {
+    display: flex;
+    align-items: center;
+    margin-right: 30px;
+}
+
+.username {
+    margin-right: 5px;
+    margin-left: 10px;
+}
+
+.right_section {
+    display: flex;
+    justify-content: space-between;
+}
+
+.right_section button {
+    margin-right: 10px;
+}
+
+.left_section {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.left_section span,
+.left_section button {
+    margin-right: 10px;
+    /* 각 요소 사이의 오른쪽 여백 설정 */
+}
+
+h3 {
+    text-align: left;
+    font-size: 30px;
+}
+
+#galleryGo,
+#detailGo,
+#replyGo {
+    margin-bottom: 80px;
+    /* 각 섹션 사이의 간격 조절 */
+}
+
+.moreInfo {
+    font-size: 15px;
+    text-align: left;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,8 @@
-import './assets/main.css'
+
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import { useKakao } from 'vue3-kakao-maps/@utils';
 
 import App from './App.vue'
 import router from './router'
@@ -10,6 +11,7 @@ import axios from '@/util/axios'
 
 const app = createApp(App)
 
+useKakao('709439cbc1ec01c73f7bca6aa652b003');
 app.use(createPinia())
 app.use(router)
 app.use(vuetify)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,6 +30,11 @@ const router = createRouter({
           // beforeEnter: onlyAuthUser,
           component: () => import("@/components/users/UserMyPage.vue"),
         },
+        {
+          path: "spotdetail",
+          name: "spot-detail",
+          component: () => import("@/components/spot_detail/SpotDetail.vue"),
+        }
       ]
     }
   ]

--- a/src/views/TheUserView.vue
+++ b/src/views/TheUserView.vue
@@ -7,6 +7,7 @@
     <router-link :to="{ name: 'user-login' }">로그인</router-link>
     <router-link :to="{ name: 'user-join' }">회원가입</router-link>
     <router-link :to="{ name: 'user-mypage' }">마이페이지</router-link>
+    <router-link :to="{ name: 'spot-detail' }">여행지 상세보기</router-link>
   </div>
 </template>
 


### PR DESCRIPTION

#### 여행지 상세 화면 구현

##### 1. 상단 부분
* 여행지의 이름, 주소를 보여주었습니다. 
* 하단 왼쪽에는 좋아요, 조회수를 볼 수 있습니다.
* 하단 오른쪽에는 저장, 프린트, 맵, 공유 아이콘을 넣어놓았습니다.(기능이 구현되지 않는다면 뺄 부분)

##### 3. 상세 정보 페이지 내 nav bar
* 사진 보기 / 상세 정보 / 댓글 세가지로 구성되어 있으며, 버튼을 클릭시 해당 위치로 이동합니다.

##### 4. 상세 정보
* 사진 보기
    * 등록된 여러 사진을 보여주기 위해 캐로셀을 넣었습니다.
* 상세 정보
    * 여행지의 설명
    * 카카오 맵으로 해당 위치 표시
    * 추가 정보(번호, 홈페이지 등등)
    * 해시태그
    * 댓글